### PR TITLE
fix getContent method returning Request instead of Response

### DIFF
--- a/src/Airtable.php
+++ b/src/Airtable.php
@@ -58,7 +58,10 @@ class Airtable
 
     function getContent($content_type,$params="",$relations=false)
     {
-        return new Request( $this, $content_type, $params, false, $relations );
+
+        $request = new Request( $this, $content_type, $params, false, $relations );
+
+        return $request->getResponse();
 	}
 
 	function saveContent($content_type,$fields)


### PR DESCRIPTION
getContent method in Airtable class now returns response of the Request.