### PR TITLE
Rate limit requests as per Airtable's API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,9 @@
    "description": "A PHP wrapper for the Airtable API Edit",
    "version": "2.2.9",
    "require": {
-       "php": ">=5.3.3"
+       "php": ">=5.4",
+      "davedevelopment/stiphle": "^0.9.2",
+       "ext-curl": "*",
+       "ext-json": "*"
    }
 }

--- a/readme.md
+++ b/readme.md
@@ -45,8 +45,9 @@ include('../src/Response.php');
 ```php
 use \TANIOS\Airtable\Airtable;
 $airtable = new Airtable(array(
-    'api_key' => 'API_KEY',
-    'base'    => 'BASE_ID'
+    'api_key'  => 'API_KEY',
+    'base'     => 'BASE_ID',
+    'throttle' => true // if you wish to throttle requests to Airtable's 5/sec limit
 ));
 ```
 ### Get all entries in table

--- a/src/Airtable.php
+++ b/src/Airtable.php
@@ -2,6 +2,8 @@
 
 namespace TANIOS\Airtable;
 
+use Stiphle\Throttle;
+
 /**
  * Airtable API Class
  *
@@ -19,12 +21,19 @@ class Airtable
     private $_key;
 
     private $_base;
+
+    private $throttle;
 	
 	public function __construct($config)
     {
         if (is_array($config)) {
             $this->setKey($config['api_key']);
             $this->setBase($config['base']);
+
+            if ($config['throttle'] == true) {
+                $this->throttle = new Throttle\LeakyBucket();
+            }
+
         } else {
             echo 'Error: __construct() - Configuration data is missing.';
         }
@@ -48,6 +57,11 @@ class Airtable
     public function getBase()
     {
         return $this->_base;
+    }
+
+    public function getThrottler()
+    {
+        return $this->throttle;
     }
 
     public function getApiUrl($request){


### PR DESCRIPTION
If enabled, a throttler can rate limit requests to 5 per second (as Airtable's API requires).