### PR TITLE
Add Typecast parameter on saveContent, and updateContent

### DIFF
--- a/src/Airtable.php
+++ b/src/Airtable.php
@@ -79,19 +79,19 @@ class Airtable
 
 	}
 
-	function updateContent($content_type,$fields)
+	function updateContent($content_type,$fields,$typecast=false)
 	{
 
         if( ! $this->_detectBatch( $fields ) )
         {
-            $fields = array('fields' => $fields);
+            $data = array('fields' => $fields, 'typecast' => $typecast);
         }
         else
         {
-            $fields = array('records' => $fields);
+            $data = array('records' => $fields, 'typecast' => $typecast);
         }
 
-		$request = new Request( $this, $content_type, $fields, 'patch' );
+		$request = new Request( $this, $content_type, $data, 'patch' );
 
 		return $request->getResponse();
 

--- a/src/Airtable.php
+++ b/src/Airtable.php
@@ -61,19 +61,19 @@ class Airtable
         return new Request( $this, $content_type, $params, false, $relations );
 	}
 
-	function saveContent($content_type,$fields)
+	function saveContent($content_type,$fields,$typecast=false)
 	{
 
 	    if( ! $this->_detectBatch( $fields ) )
         {
-            $fields = array('fields' => $fields);
+            $data = array('fields' => $fields, 'typecast' => $typecast);
         }
 	    else
         {
-            $fields = array('records' => $fields);
+            $data = array('records' => $fields, 'typecast' => $typecast);
         }
 
-		$request = new Request( $this, $content_type, $fields, true );
+		$request = new Request( $this, $content_type, $data, true );
 
 		return $request->getResponse();
 


### PR DESCRIPTION
On multiple select options, when creating or updating records, if a choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match.

