### PR TITLE
Added support for "typecast" request parameter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-   "name": "sleiman/airtable-php",
+   "name": "bizly/airtable-php",
    "license": "MIT",
    "autoload": {
      "psr-4": {
@@ -8,7 +8,7 @@
    },
 
    "description": "A PHP wrapper for the Airtable API",
-   "version": "2.4.6",
+   "version": "2.4.7",
    "require": {
        "php": ">=5.4",
       "davedevelopment/stiphle": "^0.9.2"

--- a/src/Airtable.php
+++ b/src/Airtable.php
@@ -81,16 +81,16 @@ class Airtable
         return new Request( $this, $content_type, $params, false, $relations );
 	}
 
-	function saveContent($content_type,$fields)
+	function saveContent($content_type, $fields, $typecast = false)
 	{
 
 	    if( ! $this->_detectBatch( $fields ) )
         {
-            $fields = array('fields' => $fields);
+            $fields = array('fields' => $fields, 'typecast' => $typecast);
         }
 	    else
         {
-            $fields = array('records' => $fields);
+            $fields = array('records' => $fields, 'typecast' => $typecast);
         }
 
 		$request = new Request( $this, $content_type, $fields, true );
@@ -99,16 +99,16 @@ class Airtable
 
 	}
 
-	function updateContent($content_type,$fields)
+	function updateContent($content_type, $fields, $typecast = false)
 	{
 
         if( ! $this->_detectBatch( $fields ) )
         {
-            $fields = array('fields' => $fields);
+            $fields = array('fields' => $fields, 'typecast' => $typecast);
         }
         else
         {
-            $fields = array('records' => $fields);
+            $fields = array('records' => $fields, 'typecast' => $typecast);
         }
 
 		$request = new Request( $this, $content_type, $fields, 'patch' );


### PR DESCRIPTION
AT Docs:

"When creating or updating records, if the choice string does not exactly match an existing option, the request will fail with an INVALID_MULTIPLE_CHOICE_OPTIONS error unless the typecast parameter is enabled. If typecast is enabled, a new choice will be created if one does not exactly match."

![image](https://user-images.githubusercontent.com/5090876/190269760-f8b55add-05ec-4979-824e-8b5f85e9a624.png)
